### PR TITLE
modify class rename Pattern to State

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,7 +37,6 @@ workflows:
   build-workflow:
     jobs:
       - stylecheck_and_test:
-          context: org-global
           filters:
             branches:
               only:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 click==7.0
 configparser==4.0.2
+flake8

--- a/src/sqlint/checker/violation.py
+++ b/src/sqlint/checker/violation.py
@@ -96,7 +96,7 @@ class IndentStepsViolation(Violation):
 class KeywordStyleViolation(Violation):
     def __init__(self, tree: SyntaxTree, index: int, **kwargs):
         if 'style' not in kwargs:
-            raise KeyError(f'style must be passed.')
+            raise KeyError('style must be passed.')
 
         style = kwargs['style']
 
@@ -134,9 +134,9 @@ class MultiSpacesViolation(Violation):
 class WhitespaceViolation(Violation):
     def __init__(self, tree: SyntaxTree, index: int, **kwargs):
         if 'token' not in kwargs:
-            raise KeyError(f'token must be passed.')
+            raise KeyError('token must be passed.')
         if 'position' not in kwargs:
-            raise KeyError(f'position must be passed.')
+            raise KeyError('position must be passed .')
 
         self.token = kwargs['token']
         self.position = kwargs['position']

--- a/src/sqlint/parser/base.py
+++ b/src/sqlint/parser/base.py
@@ -1,5 +1,9 @@
 import re
-from sre_parse import Pattern
+# Rename class Pattern in sre_parse to State. https://github.com/python/cpython/pull/9310
+try:
+    from sre_parse import Pattern
+except:
+    from sre_parse import State as Pattern
 from typing import List, Tuple
 
 from . import pattern

--- a/src/sqlint/parser/base.py
+++ b/src/sqlint/parser/base.py
@@ -2,7 +2,7 @@ import re
 # Rename class Pattern in sre_parse to State. https://github.com/python/cpython/pull/9310
 try:
     from sre_parse import Pattern
-except:
+except ImportError:
     from sre_parse import State as Pattern
 from typing import List, Tuple
 


### PR DESCRIPTION
# Overview

sqlint cannot work in python3.8 and above.
because [rename class Pattern in sre_parse to State](https://github.com/python/cpython/pull/9310) in used base.py
so I fixed to python3.8 and above.

and 

Changed circleci to work because it had stopped working.

![スクリーンショット 2022-02-16 13 17 42](https://user-images.githubusercontent.com/117761/154195591-f453248a-c96a-42d4-8a85-d9809f1d4baa.png)

# Test

After the above fixes, I ran the following tests.
To me, the results look the same.

```
$ sqlint tests/samples/*
tests/samples/query001.sql (L2, 1): indent steps must be 4 multiples, but 5 spaces
tests/samples/query002.sql (L10, 16): there are multiple whitespaces
tests/samples/query003.sql (L2, 7): whitespace must not be after bracket: (
tests/samples/query003.sql (L2, 22): whitespace must not be before bracket:  )
tests/samples/query004.sql (L3, 8): whitespace must be before binary operator: b+
tests/samples/query004.sql (L3, 8): whitespace must be after binary operator: +c
tests/samples/query005.sql (L2, 6): comma must be head of line
tests/samples/query005.sql (L7, 6): comma must be head of line
tests/samples/query006.sql (L1, 1): reserved keywords must be lower case: SELECT -> select
tests/samples/query006.sql (L3, 7): reserved keywords must be lower case: Count -> count
tests/samples/query007.sql (L8, 16): table_name must be at the same line as join context
tests/samples/query008.sql (L6, 5): join context must be fully: JOIN -> INNER JOIN
tests/samples/query008.sql (L10, 10): join context must be fully: LEFT JOIN -> LEFT OUTER JOIN
tests/samples/query008.sql (L14, 11): join context must be fully: RIGHT JOIN -> RIGHT OUTER JOIN
tests/samples/query008.sql (L18, 10): join context must be fully: FULL JOIN -> FULL OUTER JOIN
tests/samples/query009.sql (L6, 1): there are multiple blank lines
tests/samples/query009.sql (L9, 1): there are multiple blank lines
tests/samples/query012.sql (L3, 5): whitespace must be after comma: ,b
tests/samples/query012.sql (L7, 13): whitespace must not be before comma: ,
tests/samples/query012.sql (L7, 13): whitespace must be after comma: ,2
```





